### PR TITLE
Develop

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -1,5 +1,7 @@
 v1.2.11
 - Changed "remaining steps" message because DSM 7.1.1 has no TRIM option, even for RAID 1.
+- Added check that next md number was found.
+- Bug fix for DSM 6.2.4 not finding next md number.
 
 v1.2.10
 - Changed to show "You selected Single" instead of RAID 1 when selecting Single.

--- a/syno_create_m2_volume.sh
+++ b/syno_create_m2_volume.sh
@@ -847,7 +847,12 @@ sleep 3
 # Using "md[0-9]{1,2}" to avoid md126 and md127 etc
 lastmd=$(grep -oP "md[0-9]{1,2}" "/proc/mdstat" | sort | tail -1)
 nextmd=$((${lastmd:2} +1))
-echo "Using md$nextmd as it's the next available."
+if [[ -z $nextmd ]]; then
+    echo -e "${Error}ERROR${Off} Next md number not found!"
+    exit 1
+else
+    echo "Using md$nextmd as it's the next available."
+fi
 
 
 #--------------------------------------------------------------------

--- a/syno_create_m2_volume.sh
+++ b/syno_create_m2_volume.sh
@@ -846,7 +846,7 @@ sleep 3
 
 # Using "md[0-9]{1,2}" to avoid md126 and md127 etc
 lastmd=$(grep -oP "md[0-9]{1,2}" "/proc/mdstat" | sort | tail -1)
-nextmd=$(("${lastmd:2}" +1))
+nextmd=$((${lastmd:2} +1))
 echo "Using md$nextmd as it's the next available."
 
 

--- a/syno_create_m2_volume.sh
+++ b/syno_create_m2_volume.sh
@@ -429,7 +429,7 @@ fi                              # test
 echo -e "Unused M.2 drives found: ${#m2list[@]}\n"
 
 #echo -e "NVMe list: ${m2list[@]}\n"  # debug
-#echo -e "NVMe qty: ${#m2list[@]}\n"    # debug
+#echo -e "NVMe qty: ${#m2list[@]}\n"  # debug
 
 if [[ ${#m2list[@]} == "0" ]]; then exit; fi
 


### PR DESCRIPTION
- Changed "remaining steps" message because DSM 7.1.1 has no TRIM option, even for RAID 1.
- Added check that next md number was found.
- Bug fix for DSM 6.2.4 not finding next md number.