### PR TITLE
Develop

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -1,5 +1,7 @@
 v2.0.29
-- Better checking if creating storage was okay.
+- v2 and later are for DSM 7 only.
+  - For DSM 6 use v1 without the auto update option.
+- Improved checking if creating storage was okay.
 - Now skips exiting if creating storage pool failed. Issue #171
 
 v2.0.28

--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -1,3 +1,7 @@
+v2.0.29
+- Better checking if creating storage was okay.
+- Now skips exiting if creating storage pool failed. Issue #171
+
 v2.0.28
 - v2 and later are for DSM 7 only.
   - For DSM 6 use v1 without the auto update option.

--- a/syno_create_m2_volume.sh
+++ b/syno_create_m2_volume.sh
@@ -45,7 +45,7 @@
 # mdisk array contains list of selected nvme#n#
 
 
-scriptver="v2.0.28"
+scriptver="v2.0.29"
 script=Synology_M2_volume
 repo="007revad/Synology_M2_volume"
 scriptname=syno_create_m2_volume
@@ -145,6 +145,7 @@ selectdisk(){
                     ;;
                 *)
                     echo -e "${Red}Invalid answer!${Off} Try again." >&2
+                    #echo -e "There is no menu item $?)" >&2
                     selected_disk=""
                     ;;
             esac
@@ -407,7 +408,7 @@ if ! printf "%s\n%s\n" "$tag" "$scriptver" |
 
                             # Copy new CHANGES.txt file to script location (if script on a volume)
                             if [[ $scriptpath =~ /volume* ]]; then
-                                # Set permsissions on CHANGES.txt
+                                # Set permissions on CHANGES.txt
                                 if ! chmod 664 "/tmp/$script-$shorttag/CHANGES.txt"; then
                                     permerr=1
                                     echo -e "${Error}ERROR${Off} Failed to set permissions on:"
@@ -893,15 +894,19 @@ fi
 echo -e "\nStarting creation of the storage pool."
 if [[ $drivecheck != "yes" ]]; then
     synostgpool --create "$@" -l "$raidtype" "${partargs[@]}"
-    if [[ $? -gt "0" ]]; then
-        echo "$? synostgpool failed to create storage pool!"
-        exit 1
+    code="$?"
+    if [[ $code -gt "0" ]]; then
+        ding
+        echo "$code synostgpool failed to create storage pool!"
+        #exit 1
     fi
 else
     synostgpool --create "$@" -l "$raidtype" -c "${partargs[@]}"
-    if [[ $? -gt "0" ]]; then
-        echo "$? synostgpool failed to create storage pool!"
-        exit 1
+    code="$?"
+    if [[ $code -gt "0" ]]; then
+        ding
+        echo "$code synostgpool failed to create storage pool!"
+        #exit 1
     fi
 fi
 


### PR DESCRIPTION
v2.0.29
- v2 and later are for DSM 7 only.
  - For DSM 6 use v1 without the auto update option.
- Improved checking if creating storage was okay.
- Now skips exiting if creating storage pool failed. Issue #171